### PR TITLE
Routers & Security-Groups

### DIFF
--- a/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
@@ -4,18 +4,27 @@ import cats.effect.Sync
 import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
 import org.http4s.{Header, Uri}
-import pt.tecnico.dsi.neutron.models.{Model, Network, Port, Router, Subnet}
+import pt.tecnico.dsi.neutron.models.{FloatingIp, Model, Network, Port, SecurityGroup, Subnet}
 import pt.tecnico.dsi.neutron.services._
 
 class NeutronClient[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client: Client[F]) {
   val uri: Uri = baseUri / "v2.0"
 
-  def crudService[T <: Model](name: String) (implicit e: Encoder[T#Create], u: Encoder[T#Update], r: Decoder[T#Read]) =
-    new CrudService[F, T](uri, name, authToken) with BulkCreate[F, T]
+  val networks: CrudService[F, Network] =
+    new CrudService(uri, "network", authToken) with BulkCreate[F, Network]
 
-  val networks: CrudService[F, Network] = crudService("network")
-  val subnets: CrudService[F, Subnet] = crudService("subnet")
-  val ports: CrudService[F, Port] = crudService("port")
+  val subnets: CrudService[F, Subnet] =
+    new CrudService(uri, "subnet", authToken) with BulkCreate[F, Subnet]
 
+  val ports: CrudService[F, Port] =
+    new CrudService(uri, "port", authToken) with BulkCreate[F, Port]
+
+  val floatingIps: CrudService[F, FloatingIp] =
+    new CrudService[F, FloatingIp](uri, "floatingip", authToken) with BulkCreate[F, FloatingIp]
+
+  val securityGroups: CrudService[F, SecurityGroup] =
+    new CrudService[F, SecurityGroup](uri, "security-group", authToken) with BulkCreate[F, SecurityGroup]
+
+  val securityGroupRules: CrudService[F, SecurityGroupRules] = new SecurityGroupRules[F](uri, authToken)
   val routers: Routers[F] = new Routers[F](uri, authToken)
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
@@ -10,21 +10,17 @@ import pt.tecnico.dsi.neutron.services._
 class NeutronClient[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client: Client[F]) {
   val uri: Uri = baseUri / "v2.0"
 
-  val networks: CrudService[F, Network] =
-    new CrudService(uri, "network", authToken) with BulkCreate[F, Network]
-
-  val subnets: CrudService[F, Subnet] =
-    new CrudService(uri, "subnet", authToken) with BulkCreate[F, Subnet]
-
-  val ports: CrudService[F, Port] =
-    new CrudService(uri, "port", authToken) with BulkCreate[F, Port]
+  val networks = new CrudService[F, Network] (uri, "network", authToken) with BulkCreate[F, Network]
+  val subnets  = new CrudService[F, Subnet](uri, "subnet", authToken) with BulkCreate[F, Subnet]
+  val ports    = new CrudService[F, Port](uri, "port", authToken) with BulkCreate[F, Port]
 
   val floatingIps: CrudService[F, FloatingIp] =
-    new CrudService[F, FloatingIp](uri, "floatingip", authToken) with BulkCreate[F, FloatingIp]
+    new CrudService[F, FloatingIp](uri, "floatingip", authToken) {}
 
   val securityGroups: CrudService[F, SecurityGroup] =
-    new CrudService[F, SecurityGroup](uri, "security-group", authToken) with BulkCreate[F, SecurityGroup]
+    new CrudService[F, SecurityGroup](uri, "security-group", authToken) {}
 
-  val securityGroupRules: CrudService[F, SecurityGroupRules] = new SecurityGroupRules[F](uri, authToken)
+  val securityGroupRules: SecurityGroupRules[F] = new SecurityGroupRules[F](uri, authToken)
+
   val routers: Routers[F] = new Routers[F](uri, authToken)
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
@@ -5,15 +5,15 @@ import org.http4s.client.Client
 import org.http4s.{Header, Uri}
 import pt.tecnico.dsi.neutron.services._
 
-class NeutronClient[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client: Client[F]) {
+class NeutronClient[F[_] : Sync](baseUri: Uri, authToken: Header)(implicit client: Client[F]) {
 
   val uri: Uri = if (baseUri.path.endsWith("v2.0") || baseUri.path.endsWith("v2.0/")) baseUri else baseUri / "v2.0"
 
-  val networks           = new Networks[F](uri, authToken)
-  val subnets            = new Subnets[F](uri, authToken)
-  val ports              = new Ports[F](uri, authToken)
-  val routers            = new Routers[F](uri, authToken)
-  val floatingIps        = new FloatingIps[F](uri, authToken)
-  val securityGroups     = new SecurityGroups[F](uri, authToken)
+  val networks = new Networks[F](uri, authToken)
+  val subnets = new Subnets[F](uri, authToken)
+  val ports = new Ports[F](uri, authToken)
+  val routers = new Routers[F](uri, authToken)
+  val floatingIps = new FloatingIps[F](uri, authToken)
+  val securityGroups = new SecurityGroups[F](uri, authToken)
   val securityGroupRules = new SecurityGroupRules[F](uri, authToken)
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
@@ -1,26 +1,19 @@
 package pt.tecnico.dsi.neutron
 
 import cats.effect.Sync
-import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
 import org.http4s.{Header, Uri}
-import pt.tecnico.dsi.neutron.models.{FloatingIp, Model, Network, Port, SecurityGroup, Subnet}
 import pt.tecnico.dsi.neutron.services._
 
 class NeutronClient[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client: Client[F]) {
-  val uri: Uri = baseUri / "v2.0"
 
-  val networks = new CrudService[F, Network] (uri, "network", authToken) with BulkCreate[F, Network]
-  val subnets  = new CrudService[F, Subnet](uri, "subnet", authToken) with BulkCreate[F, Subnet]
-  val ports    = new CrudService[F, Port](uri, "port", authToken) with BulkCreate[F, Port]
+  val uri: Uri = if (baseUri.path.endsWith("v2.0") || baseUri.path.endsWith("v2.0/")) baseUri else baseUri / "v2.0"
 
-  val floatingIps: CrudService[F, FloatingIp] =
-    new CrudService[F, FloatingIp](uri, "floatingip", authToken) {}
-
-  val securityGroups: CrudService[F, SecurityGroup] =
-    new CrudService[F, SecurityGroup](uri, "security-group", authToken) {}
-
-  val securityGroupRules: SecurityGroupRules[F] = new SecurityGroupRules[F](uri, authToken)
-
-  val routers: Routers[F] = new Routers[F](uri, authToken)
+  val networks           = new Networks[F](uri, authToken)
+  val subnets            = new Subnets[F](uri, authToken)
+  val ports              = new Ports[F](uri, authToken)
+  val routers            = new Routers[F](uri, authToken)
+  val floatingIps        = new FloatingIps[F](uri, authToken)
+  val securityGroups     = new SecurityGroups[F](uri, authToken)
+  val securityGroupRules = new SecurityGroupRules[F](uri, authToken)
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
@@ -17,4 +17,5 @@ class NeutronClient[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client
   val subnets: CrudService[F, Subnet] = crudService("subnet")
   val ports: CrudService[F, Port] = crudService("port")
 
+  val routers: Routers[F] = new Routers[F](uri, authToken)
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/NeutronClient.scala
@@ -4,7 +4,7 @@ import cats.effect.Sync
 import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
 import org.http4s.{Header, Uri}
-import pt.tecnico.dsi.neutron.models.{Model, Network, Port, Subnet}
+import pt.tecnico.dsi.neutron.models.{Model, Network, Port, Router, Subnet}
 import pt.tecnico.dsi.neutron.services._
 
 class NeutronClient[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client: Client[F]) {
@@ -13,7 +13,8 @@ class NeutronClient[F[_]: Sync](baseUri: Uri, authToken: Header)(implicit client
   def crudService[T <: Model](name: String) (implicit e: Encoder[T#Create], u: Encoder[T#Update], r: Decoder[T#Read]) =
     new CrudService[F, T](uri, name, authToken) with BulkCreate[F, T]
 
-  val networks: CrudService[F, Network] = crudService[Network]("network")
-  val subnets: CrudService[F, Subnet] = crudService[Subnet]("subnet")
-  val ports: CrudService[F, Port] = crudService[Port]("port")
+  val networks: CrudService[F, Network] = crudService("network")
+  val subnets: CrudService[F, Subnet] = crudService("subnet")
+  val ports: CrudService[F, Port] = crudService("port")
+
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
@@ -2,8 +2,8 @@ package pt.tecnico.dsi.neutron.models
 
 import java.time.LocalDateTime
 
+import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
 import io.circe.{Decoder, Encoder}
-import io.circe.derivation.{deriveDecoder, renaming, deriveEncoder}
 
 object FloatingIp {
 
@@ -55,6 +55,7 @@ object FloatingIp {
     tags: List[String],
     portForwardings: List[Map[String, String]]
   )
+
 }
 
 sealed trait FloatingIp extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
@@ -1,0 +1,64 @@
+package pt.tecnico.dsi.neutron.models
+
+import java.time.LocalDateTime
+
+import io.circe.{Decoder, Encoder}
+import io.circe.derivation.{deriveDecoder, renaming, deriveEncoder}
+
+object FloatingIp {
+
+  object Read {
+    implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
+  }
+
+  object Update {
+    implicit val decoder: Encoder[Update] = deriveEncoder(renaming.snakeCase)
+  }
+
+  object Create {
+    implicit val decoder: Encoder[Create] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Create(
+    portId: Option[String],
+    projectId: Option[String],
+    fixedIpAddress: Option[String],
+    floatingIpAddress: Option[String],
+    description: Option[String],
+    subnetId: Option[String],
+    dnsDomain: Option[String],
+    dnsName: Option[String],
+    floatingNetworkId: Option[String]
+  )
+
+  case class Update(
+    portId: String,
+    fixedIpAddress: Option[String],
+    description: Option[String]
+  )
+
+  case class Read(
+    routerId: String,
+    status: String,
+    description: String,
+    dnsDomain: String,
+    dnsName: String,
+    portDetails: String,
+    projectId: String,
+    createdAt: LocalDateTime,
+    updatedAt: LocalDateTime,
+    revisionNumber: Integer,
+    floatingNetworkId: String,
+    fixedIpAddress: String,
+    floatingIpAddress: String,
+    portId: String,
+    tags: List[String],
+    portForwardings: List[Map[String, String]]
+  )
+}
+
+sealed trait FloatingIp extends Model {
+  type Update = FloatingIp.Update
+  type Create = FloatingIp.Create
+  type Read = FloatingIp.Read
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
@@ -20,21 +20,21 @@ object FloatingIp {
   }
 
   case class Create(
-    portId: Option[String],
-    projectId: Option[String],
-    fixedIpAddress: Option[String],
-    floatingIpAddress: Option[String],
-    description: Option[String],
-    subnetId: Option[String],
-    dnsDomain: Option[String],
-    dnsName: Option[String],
-    floatingNetworkId: Option[String]
+    portId: Option[String] = None,
+    projectId: Option[String] = None,
+    fixedIpAddress: Option[String] = None,
+    floatingIpAddress: Option[String] = None,
+    description: Option[String] = None,
+    subnetId: Option[String] = None,
+    dnsDomain: Option[String] = None,
+    dnsName: Option[String] = None,
+    floatingNetworkId: Option[String] = None
   )
 
   case class Update(
     portId: String,
-    fixedIpAddress: Option[String],
-    description: Option[String]
+    fixedIpAddress: Option[String] = None,
+    description: Option[String] = None
   )
 
   case class Read(

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
@@ -11,32 +11,6 @@ object FloatingIp {
     implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
   }
 
-  object Update {
-    implicit val decoder: Encoder[Update] = deriveEncoder(renaming.snakeCase)
-  }
-
-  object Create {
-    implicit val decoder: Encoder[Create] = deriveEncoder(renaming.snakeCase)
-  }
-
-  case class Create(
-    portId: Option[String] = None,
-    projectId: Option[String] = None,
-    fixedIpAddress: Option[String] = None,
-    floatingIpAddress: Option[String] = None,
-    description: Option[String] = None,
-    subnetId: Option[String] = None,
-    dnsDomain: Option[String] = None,
-    dnsName: Option[String] = None,
-    floatingNetworkId: Option[String] = None
-  )
-
-  case class Update(
-    portId: String,
-    fixedIpAddress: Option[String] = None,
-    description: Option[String] = None
-  )
-
   case class Read(
     routerId: String,
     status: String,
@@ -56,6 +30,31 @@ object FloatingIp {
     portForwardings: List[Map[String, String]]
   )
 
+  object Create {
+    implicit val decoder: Encoder[Create] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Create(
+    portId: Option[String] = None,
+    projectId: Option[String] = None,
+    fixedIpAddress: Option[String] = None,
+    floatingIpAddress: Option[String] = None,
+    description: Option[String] = None,
+    subnetId: Option[String] = None,
+    dnsDomain: Option[String] = None,
+    dnsName: Option[String] = None,
+    floatingNetworkId: Option[String] = None
+  )
+
+  object Update {
+    implicit val decoder: Encoder[Update] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Update(
+    portId: String,
+    fixedIpAddress: Option[String] = None,
+    description: Option[String] = None
+  )
 }
 
 sealed trait FloatingIp extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/FloatingIp.scala
@@ -1,11 +1,23 @@
 package pt.tecnico.dsi.neutron.models
 
+import java.net.InetAddress
 import java.time.LocalDateTime
 
 import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
 import io.circe.{Decoder, Encoder}
 
 object FloatingIp {
+
+  object PortForwarding {
+    implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
+  }
+
+  case class PortForwarding(
+    protocol: String,
+    internalIpAddress: InetAddress,
+    internalPort: Integer,
+    externalPort: Integer
+  )
 
   object Read {
     implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
@@ -27,7 +39,7 @@ object FloatingIp {
     floatingIpAddress: String,
     portId: String,
     tags: List[String],
-    portForwardings: List[Map[String, String]]
+    portForwardings: List[PortForwarding]
   )
 
   object Create {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Network.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Network.scala
@@ -8,19 +8,21 @@ import io.circe.{Decoder, Encoder, HCursor}
 object Network {
 
   // TODO: Rethink this
-  implicit val decoder: Decoder[Read] = (c: HCursor) => {
-    for {
-      providerNetworkType      <- c.downField("provider:network_type").as[String]
-      providerPhysicalNetwork  <- c.downField("provider:physical_network").as[String]
-      providerSegmentationId   <- c.downField("provider:segmentation_id").as[Integer]
-      routerExternal           <- c.downField("router:external").as[Boolean]
-      network                  <- c.as[Read](deriveDecoder(renaming.snakeCase))
-    } yield network.copy(
-      providerNetworkType = providerNetworkType,
-      providerPhysicalNetwork = providerPhysicalNetwork,
-      providerSegmentationId = providerSegmentationId,
-      routerExternal = routerExternal
-    )
+  object Read {
+    implicit val decoder: Decoder[Read] = (c: HCursor) => {
+      for {
+        providerNetworkType      <- c.downField("provider:network_type").as[String]
+        providerPhysicalNetwork  <- c.downField("provider:physical_network").as[String]
+        providerSegmentationId   <- c.downField("provider:segmentation_id").as[Integer]
+        routerExternal           <- c.downField("router:external").as[Boolean]
+        network                  <- c.as[Read](deriveDecoder(renaming.snakeCase))
+      } yield network.copy(
+        providerNetworkType = providerNetworkType,
+        providerPhysicalNetwork = providerPhysicalNetwork,
+        providerSegmentationId = providerSegmentationId,
+        routerExternal = routerExternal
+      )
+    }
   }
 
   object Create {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Network.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Network.scala
@@ -11,11 +11,11 @@ object Network {
   object Read {
     implicit val decoder: Decoder[Read] = (c: HCursor) => {
       for {
-        providerNetworkType      <- c.downField("provider:network_type").as[String]
-        providerPhysicalNetwork  <- c.downField("provider:physical_network").as[String]
-        providerSegmentationId   <- c.downField("provider:segmentation_id").as[Integer]
-        routerExternal           <- c.downField("router:external").as[Boolean]
-        network                  <- c.as[Read](deriveDecoder(renaming.snakeCase))
+        providerNetworkType <- c.downField("provider:network_type").as[String]
+        providerPhysicalNetwork <- c.downField("provider:physical_network").as[String]
+        providerSegmentationId <- c.downField("provider:segmentation_id").as[Integer]
+        routerExternal <- c.downField("router:external").as[Boolean]
+        network <- c.as[Read](deriveDecoder(renaming.snakeCase))
       } yield network.copy(
         providerNetworkType = providerNetworkType,
         providerPhysicalNetwork = providerPhysicalNetwork,
@@ -99,6 +99,7 @@ object Network {
     isDefault: Boolean,
     tags: List[String],
   )
+
 }
 
 sealed trait Network extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Network.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Network.scala
@@ -25,6 +25,37 @@ object Network {
     }
   }
 
+  sealed case class Read(
+    adminStateUp: Boolean,
+    availabilityZoneHints: List[String], // ???
+    availabilityZones: List[String], // ???
+    createdAt: LocalDateTime,
+    dnsDomain: String,
+    ipv4AddressScope: String,
+    ipv6AddressScope: String,
+    l2Adjacency: Boolean,
+    mtu: Integer,
+    name: String,
+    portSecurityEnabled: Boolean,
+    projectId: String,
+    // provider:network_type
+    providerNetworkType: String,
+    providerPhysicalNetwork: String,
+    providerSegmentationId: Integer,
+    qosPolicyId: String,
+    revision_number: Integer,
+    // router:external
+    routerExternal: Boolean,
+    segments: List[String], // ???
+    shared: Boolean,
+    subnets: List[String], //???
+    updatedAt: LocalDateTime,
+    vlanTransparent: Boolean,
+    description: String,
+    isDefault: Boolean,
+    tags: List[String],
+  )
+
   object Create {
     implicit val encoder: Encoder[Create] = deriveEncoder(renaming.snakeCase)
   }
@@ -67,37 +98,6 @@ object Network {
     isDefault: Option[Boolean] = None,
     segments: Option[List[String]] = None,
     shared: Option[Boolean] = None,
-  )
-
-  sealed case class Read(
-    adminStateUp: Boolean,
-    availabilityZoneHints: List[String], // ???
-    availabilityZones: List[String], // ???
-    createdAt: LocalDateTime,
-    dnsDomain: String,
-    ipv4AddressScope: String,
-    ipv6AddressScope: String,
-    l2Adjacency: Boolean,
-    mtu: Integer,
-    name: String,
-    portSecurityEnabled: Boolean,
-    projectId: String,
-    // provider:network_type
-    providerNetworkType: String,
-    providerPhysicalNetwork: String,
-    providerSegmentationId: Integer,
-    qosPolicyId: String,
-    revision_number: Integer,
-    // router:external
-    routerExternal: Boolean,
-    segments: List[String], // ???
-    shared: Boolean,
-    subnets: List[String], //???
-    updatedAt: LocalDateTime,
-    vlanTransparent: Boolean,
-    description: String,
-    isDefault: Boolean,
-    tags: List[String],
   )
 
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Port.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Port.scala
@@ -24,7 +24,7 @@ object Port {
     adminStateUp: Option[Boolean] = None,
     allowedAddressPairs: Option[List[String]] = None,
     bindingHostId: Option[String] = None,
-    bindingProfile: Option[Map[String,String]] = None,
+    bindingProfile: Option[Map[String, String]] = None,
     bindingVnicType: Option[String] = None,
     dataPlaneStatus: Option[String] = None,
     deviceId: Option[String] = None,
@@ -32,7 +32,7 @@ object Port {
     deviceOwner: Option[String] = None,
     dnsName: Option[String] = None,
     dnsDomain: Option[String] = None,
-    extraDhcpOpts: Option[List[Map[String,String]]] = None,
+    extraDhcpOpts: Option[List[Map[String, String]]] = None,
     fixedIps: Option[List[String]] = None,
     macAddress: Option[String] = None,
     securityGrous: Option[List[String]] = None,
@@ -52,13 +52,13 @@ object Port {
     adminStateUp: Option[Boolean] = None,
     allowedAddressPairs: Option[List[String]] = None,
     bindingHostId: Option[String] = None,
-    bindingProfile: Option[Map[String,String]] = None,
+    bindingProfile: Option[Map[String, String]] = None,
     bindingVifType: Option[String] = None,
     deviceId: Option[String] = None,
     deviceOwner: Option[String] = None,
     dnsName: Option[String] = None,
     dnsDomain: Option[String] = None,
-    extraDhcpOpts: Option[List[Map[String,String]]] = None,
+    extraDhcpOpts: Option[List[Map[String, String]]] = None,
     fixedIps: Option[List[String]] = None,
     macAddress: Option[String] = None,
   )
@@ -79,7 +79,7 @@ object Port {
     dnsAssignment: Map[String, String],
     dnsDomain: String,
     dnsName: String,
-    extraDhcpOpts: List[Map[String,String]],
+    extraDhcpOpts: List[Map[String, String]],
     fixedIps: List[String],
     ipAllocation: String,
     macAddress: String,
@@ -98,6 +98,7 @@ object Port {
     uplinkStatusPropagation: Boolean,
     macLearningEnabled: Boolean
   )
+
 }
 
 sealed trait Port extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Port.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Port.scala
@@ -11,58 +11,6 @@ object Port {
     implicit val codec: Decoder[Read] = deriveDecoder(renaming.snakeCase)
   }
 
-  object Create {
-    implicit val codec: Encoder[Create] = deriveEncoder(renaming.snakeCase)
-  }
-
-  object Update {
-    implicit val codec: Encoder[Update] = deriveEncoder(renaming.snakeCase)
-  }
-
-  case class Update(
-    name: Option[String] = None,
-    adminStateUp: Option[Boolean] = None,
-    allowedAddressPairs: Option[List[String]] = None,
-    bindingHostId: Option[String] = None,
-    bindingProfile: Option[Map[String, String]] = None,
-    bindingVnicType: Option[String] = None,
-    dataPlaneStatus: Option[String] = None,
-    deviceId: Option[String] = None,
-    description: Option[String] = None,
-    deviceOwner: Option[String] = None,
-    dnsName: Option[String] = None,
-    dnsDomain: Option[String] = None,
-    extraDhcpOpts: Option[List[Map[String, String]]] = None,
-    fixedIps: Option[List[String]] = None,
-    macAddress: Option[String] = None,
-    securityGrous: Option[List[String]] = None,
-    qosPolicyId: Option[String] = None,
-    macLearningEnabled: Option[Boolean] = None,
-  )
-
-  case class Create(
-    uplinkStatusPropagation: Option[Boolean] = None,
-    macLearningEnabled: Option[Boolean] = None,
-    securityGrous: Option[List[String]] = None,
-    qosPolicyId: Option[String] = None,
-    projectId: Option[String] = None,
-    name: Option[String] = None,
-    networkId: Option[String] = None,
-    portSecurityEnabled: Option[Boolean] = None,
-    adminStateUp: Option[Boolean] = None,
-    allowedAddressPairs: Option[List[String]] = None,
-    bindingHostId: Option[String] = None,
-    bindingProfile: Option[Map[String, String]] = None,
-    bindingVifType: Option[String] = None,
-    deviceId: Option[String] = None,
-    deviceOwner: Option[String] = None,
-    dnsName: Option[String] = None,
-    dnsDomain: Option[String] = None,
-    extraDhcpOpts: Option[List[Map[String, String]]] = None,
-    fixedIps: Option[List[String]] = None,
-    macAddress: Option[String] = None,
-  )
-
   case class Read(
     adminStateUp: Boolean,
     allowedAddressPairs: List[String],
@@ -99,6 +47,57 @@ object Port {
     macLearningEnabled: Boolean
   )
 
+  object Create {
+    implicit val codec: Encoder[Create] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Create(
+    uplinkStatusPropagation: Option[Boolean] = None,
+    macLearningEnabled: Option[Boolean] = None,
+    securityGrous: Option[List[String]] = None,
+    qosPolicyId: Option[String] = None,
+    projectId: Option[String] = None,
+    name: Option[String] = None,
+    networkId: Option[String] = None,
+    portSecurityEnabled: Option[Boolean] = None,
+    adminStateUp: Option[Boolean] = None,
+    allowedAddressPairs: Option[List[String]] = None,
+    bindingHostId: Option[String] = None,
+    bindingProfile: Option[Map[String, String]] = None,
+    bindingVifType: Option[String] = None,
+    deviceId: Option[String] = None,
+    deviceOwner: Option[String] = None,
+    dnsName: Option[String] = None,
+    dnsDomain: Option[String] = None,
+    extraDhcpOpts: Option[List[Map[String, String]]] = None,
+    fixedIps: Option[List[String]] = None,
+    macAddress: Option[String] = None,
+  )
+
+  object Update {
+    implicit val codec: Encoder[Update] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Update(
+    name: Option[String] = None,
+    adminStateUp: Option[Boolean] = None,
+    allowedAddressPairs: Option[List[String]] = None,
+    bindingHostId: Option[String] = None,
+    bindingProfile: Option[Map[String, String]] = None,
+    bindingVnicType: Option[String] = None,
+    dataPlaneStatus: Option[String] = None,
+    deviceId: Option[String] = None,
+    description: Option[String] = None,
+    deviceOwner: Option[String] = None,
+    dnsName: Option[String] = None,
+    dnsDomain: Option[String] = None,
+    extraDhcpOpts: Option[List[Map[String, String]]] = None,
+    fixedIps: Option[List[String]] = None,
+    macAddress: Option[String] = None,
+    securityGrous: Option[List[String]] = None,
+    qosPolicyId: Option[String] = None,
+    macLearningEnabled: Option[Boolean] = None,
+  )
 }
 
 sealed trait Port extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Route.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Route.scala
@@ -1,0 +1,11 @@
+package pt.tecnico.dsi.neutron.models
+
+import io.circe.{Codec, Decoder, Encoder}
+import io.circe.derivation.{deriveEncoder, deriveDecoder, renaming}
+
+object Route {
+  implicit val encoder: Encoder[Route] = deriveEncoder(renaming.snakeCase)
+  implicit val decoder: Decoder[Route] = deriveDecoder(renaming.snakeCase)
+}
+
+case class Route(destination: String, nexthop: String)

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Route.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Route.scala
@@ -1,5 +1,7 @@
 package pt.tecnico.dsi.neutron.models
 
+import java.net.InetAddress
+
 import io.circe.Codec
 import io.circe.derivation.{deriveCodec, renaming}
 
@@ -7,4 +9,4 @@ object Route {
   implicit val codec: Codec[Route] = deriveCodec(renaming.snakeCase)
 }
 
-case class Route(destination: String, nexthop: String)
+case class Route(destination: String, nexthop: InetAddress)

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Route.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Route.scala
@@ -1,11 +1,10 @@
 package pt.tecnico.dsi.neutron.models
 
-import io.circe.{Codec, Decoder, Encoder}
-import io.circe.derivation.{deriveEncoder, deriveDecoder, renaming}
+import io.circe.Codec
+import io.circe.derivation.{deriveCodec, renaming}
 
 object Route {
-  implicit val encoder: Encoder[Route] = deriveEncoder(renaming.snakeCase)
-  implicit val decoder: Decoder[Route] = deriveDecoder(renaming.snakeCase)
+  implicit val codec: Codec[Route] = deriveCodec(renaming.snakeCase)
 }
 
 case class Route(destination: String, nexthop: String)

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
@@ -1,0 +1,80 @@
+package pt.tecnico.dsi.neutron.models
+
+import java.time.LocalDateTime
+
+import io.circe.{Decoder, Encoder}
+import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming, deriveCodec}
+
+object Router extends Model {
+
+  object Read {
+    implicit val codec: Decoder[Read] = deriveDecoder(renaming.snakeCase)
+  }
+
+  object Create {
+    implicit val codec: Encoder[Create] = deriveEncoder(renaming.snakeCase)
+  }
+
+  object Update {
+    implicit val codec: Encoder[Update] = deriveEncoder(renaming.snakeCase)
+  }
+
+  object ConntrackHelper {
+    implicit val decoder: Decoder[ConntrackHelper] = deriveDecoder(renaming.snakeCase)
+  }
+
+  case class ConntrackHelper(protocol: String, helper: String, port: Integer)
+
+  case class Read(
+    projectId: String,
+    name: String,
+    description: String,
+    adminStateUp: Boolean,
+    status: String, // ???
+    externalGatewayInfo: Map[String, String], // ???
+    revisionNumber: Integer,
+    routes: List[Map[String, String]], // ???
+    destination: String,
+    nexthop: String, // Ipv4Address
+    distributed: Boolean,
+    ha: Boolean,
+    availabilityZoneHints: List[String], //??
+    availabilityZones: List[String], //???
+    serviceTypeId: String, //???
+    flavorId: String, //???
+    createdAt: LocalDateTime,
+    updatedAt: LocalDateTime,
+    tags: List[String],
+    conntrack_helpers: List[ConntrackHelper]
+
+  )
+
+  case class Create(
+    projectId: Option[String],
+    name: Option[String],
+    description: Option[String],
+    adminStateUp: Option[Boolean],
+    externalGatewayInfo: Option[Map[String, String]],
+    distributed: Option[Boolean],
+    ha: Option[Boolean],
+    availabilityZoneHints: Option[List[String]],
+    serviceTypeId: Option[String],
+    flavorId: Option[String],
+  )
+
+  case class Update(
+    name: Option[String],
+    description: Option[String],
+    adminStateUp: Option[Boolean],
+    externalGatewayInfo: Option[Map[String, String]],
+    distributed: Option[Boolean],
+    ha: Option[Boolean],
+    routes: List[Map[String, String]],
+  )
+}
+
+sealed trait Router extends Model {
+  type Update = Router.Update
+  type Create = Router.Create
+  type Read = Router.Read
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
@@ -1,9 +1,10 @@
 package pt.tecnico.dsi.neutron.models
 
+import java.net.Inet4Address
 import java.time.LocalDateTime
 
+import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
 import io.circe.{Decoder, Encoder}
-import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming, deriveCodec}
 
 object Router extends Model {
 
@@ -35,7 +36,7 @@ object Router extends Model {
     revisionNumber: Integer,
     routes: List[Map[String, String]], // ???
     destination: String,
-    nexthop: String, // Ipv4Address
+    nexthop: String,
     distributed: Boolean,
     ha: Boolean,
     availabilityZoneHints: List[String], //??
@@ -50,26 +51,26 @@ object Router extends Model {
   )
 
   case class Create(
-    projectId: Option[String],
-    name: Option[String],
-    description: Option[String],
-    adminStateUp: Option[Boolean],
-    externalGatewayInfo: Option[Map[String, String]],
-    distributed: Option[Boolean],
-    ha: Option[Boolean],
-    availabilityZoneHints: Option[List[String]],
-    serviceTypeId: Option[String],
-    flavorId: Option[String],
+    projectId: Option[String] = None,
+    name: Option[String] = None,
+    description: Option[String] = None,
+    adminStateUp: Option[Boolean] = None ,
+    externalGatewayInfo: Option[Map[String, String]] = None,
+    distributed: Option[Boolean] = None,
+    ha: Option[Boolean] = None,
+    availabilityZoneHints: Option[List[String]] = None,
+    serviceTypeId: Option[String] = None,
+    flavorId: Option[String] = None,
   )
 
   case class Update(
-    name: Option[String],
-    description: Option[String],
-    adminStateUp: Option[Boolean],
-    externalGatewayInfo: Option[Map[String, String]],
-    distributed: Option[Boolean],
-    ha: Option[Boolean],
-    routes: List[Map[String, String]],
+    name: Option[String] = None,
+    description: Option[String] = None,
+    adminStateUp: Option[Boolean] = None,
+    externalGatewayInfo: Option[Map[String, String]] = None,
+    distributed: Option[Boolean] = None,
+    ha: Option[Boolean] = None,
+    routes: Option[List[Map[String, String]]] = None,
   )
 }
 

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
@@ -1,6 +1,6 @@
 package pt.tecnico.dsi.neutron.models
 
-import java.net.Inet4Address
+import java.net.InetAddress
 import java.time.LocalDateTime
 
 import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
@@ -36,7 +36,7 @@ object Router extends Model {
     revisionNumber: Integer,
     routes: List[Map[String, String]], // ???
     destination: String,
-    nexthop: String,
+    nexthop: InetAddress,
     distributed: Boolean,
     ha: Boolean,
     availabilityZoneHints: List[String], //??

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
@@ -12,20 +12,6 @@ object Router extends Model {
     implicit val codec: Decoder[Read] = deriveDecoder(renaming.snakeCase)
   }
 
-  object Create {
-    implicit val codec: Encoder[Create] = deriveEncoder(renaming.snakeCase)
-  }
-
-  object Update {
-    implicit val codec: Encoder[Update] = deriveEncoder(renaming.snakeCase)
-  }
-
-  object ConntrackHelper {
-    implicit val decoder: Decoder[ConntrackHelper] = deriveDecoder(renaming.snakeCase)
-  }
-
-  case class ConntrackHelper(protocol: String, helper: String, port: Integer)
-
   case class Read(
     projectId: String,
     name: String,
@@ -47,8 +33,11 @@ object Router extends Model {
     updatedAt: LocalDateTime,
     tags: List[String],
     conntrack_helpers: List[ConntrackHelper]
-
   )
+
+  object Create {
+    implicit val codec: Encoder[Create] = deriveEncoder(renaming.snakeCase)
+  }
 
   case class Create(
     projectId: Option[String] = None,
@@ -63,6 +52,10 @@ object Router extends Model {
     flavorId: Option[String] = None,
   )
 
+  object Update {
+    implicit val codec: Encoder[Update] = deriveEncoder(renaming.snakeCase)
+  }
+
   case class Update(
     name: Option[String] = None,
     description: Option[String] = None,
@@ -73,6 +66,11 @@ object Router extends Model {
     routes: Option[List[Map[String, String]]] = None,
   )
 
+  object ConntrackHelper {
+    implicit val decoder: Decoder[ConntrackHelper] = deriveDecoder(renaming.snakeCase)
+  }
+
+  case class ConntrackHelper(protocol: String, helper: String, port: Integer)
 }
 
 sealed trait Router extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Router.scala
@@ -54,7 +54,7 @@ object Router extends Model {
     projectId: Option[String] = None,
     name: Option[String] = None,
     description: Option[String] = None,
-    adminStateUp: Option[Boolean] = None ,
+    adminStateUp: Option[Boolean] = None,
     externalGatewayInfo: Option[Map[String, String]] = None,
     distributed: Option[Boolean] = None,
     ha: Option[Boolean] = None,
@@ -72,6 +72,7 @@ object Router extends Model {
     ha: Option[Boolean] = None,
     routes: Option[List[Map[String, String]]] = None,
   )
+
 }
 
 sealed trait Router extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
@@ -14,7 +14,6 @@ object RouterInterface {
     subnetId: Option[String] = None,
     portId: Option[String] = None,
   )
-
 }
 
 case class RouterInterface(

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
@@ -4,10 +4,10 @@ import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
 import io.circe.{Decoder, Encoder}
 
 object RouterInterface {
-  implicit val codec: Decoder[RouterInterface] = deriveDecoder(renaming.snakeCase)
+  implicit val decoder: Decoder[RouterInterface] = deriveDecoder(renaming.snakeCase)
 
   object Remove {
-    implicit val codec: Encoder[Remove] = deriveEncoder(renaming.snakeCase)
+    implicit val encoder: Encoder[Remove] = deriveEncoder(renaming.snakeCase)
   }
 
   case class Remove (

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
@@ -1,0 +1,25 @@
+package pt.tecnico.dsi.neutron.models
+
+import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
+import io.circe.{Decoder, Encoder}
+
+object RouterInterface {
+  implicit val codec: Decoder[RouterInterface] = deriveDecoder(renaming.snakeCase)
+
+  object Remove {
+    implicit val codec: Encoder[Remove] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Remove (
+    subnetId: Option[String],
+    portId: Option[String],
+  )
+}
+
+case class RouterInterface(
+  subnetId: String,
+  projectId: String,
+  portId: String,
+  networkId: String,
+  tags: List[String]
+)

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
@@ -10,10 +10,11 @@ object RouterInterface {
     implicit val encoder: Encoder[Remove] = deriveEncoder(renaming.snakeCase)
   }
 
-  case class Remove (
+  case class Remove(
     subnetId: Option[String] = None,
     portId: Option[String] = None,
   )
+
 }
 
 case class RouterInterface(

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/RouterInterface.scala
@@ -11,8 +11,8 @@ object RouterInterface {
   }
 
   case class Remove (
-    subnetId: Option[String],
-    portId: Option[String],
+    subnetId: Option[String] = None,
+    portId: Option[String] = None,
   )
 }
 

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroup.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroup.scala
@@ -2,8 +2,8 @@ package pt.tecnico.dsi.neutron.models
 
 import java.time.LocalDateTime
 
+import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
 import io.circe.{Decoder, Encoder}
-import io.circe.derivation.{deriveDecoder, renaming, deriveEncoder}
 
 object SecurityGroup {
 
@@ -43,6 +43,7 @@ object SecurityGroup {
     securityGroupRoles: List[SecurityGroupRule], // Security Group Roles Object
     stateful: Option[String]
   )
+
 }
 
 sealed trait SecurityGroup extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroup.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroup.scala
@@ -1,0 +1,52 @@
+package pt.tecnico.dsi.neutron.models
+
+import java.time.LocalDateTime
+
+import io.circe.{Decoder, Encoder}
+import io.circe.derivation.{deriveDecoder, renaming, deriveEncoder}
+
+object SecurityGroup {
+
+  object Read {
+    implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
+  }
+
+  object Update {
+    implicit val decoder: Encoder[Update] = deriveEncoder(renaming.snakeCase)
+  }
+
+  object Create {
+    implicit val decoder: Encoder[Create] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Create(
+    projectId: String,
+    description: Option[String],
+    stateful: Option[Boolean]
+  )
+
+  case class Update(
+    description: Option[String],
+    name: Option[String],
+    stateful: Option[Boolean]
+  )
+
+  case class Read(
+    name: String,
+    status: String,
+    description: String,
+    projectId: String,
+    createdAt: LocalDateTime,
+    updatedAt: LocalDateTime,
+    revisionNumber: Integer,
+    tags: List[String],
+    securityGroupRoles: List[SecurityGroupRule], // Security Group Roles Object
+    stateful: Option[String]
+  )
+}
+
+sealed trait SecurityGroup extends Model {
+  type Update = SecurityGroup.Update
+  type Create = SecurityGroup.Create
+  type Read = SecurityGroup.Read
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroup.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroup.scala
@@ -21,14 +21,14 @@ object SecurityGroup {
 
   case class Create(
     projectId: String,
-    description: Option[String],
-    stateful: Option[Boolean]
+    description: Option[String] = None,
+    stateful: Option[Boolean] = None
   )
 
   case class Update(
-    description: Option[String],
-    name: Option[String],
-    stateful: Option[Boolean]
+    description: Option[String] = None,
+    name: Option[String] = None,
+    stateful: Option[Boolean] = None
   )
 
   case class Read(

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroup.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroup.scala
@@ -7,13 +7,16 @@ import io.circe.{Decoder, Encoder}
 
 object SecurityGroup {
 
-  object Read {
-    implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
-  }
 
   object Update {
     implicit val decoder: Encoder[Update] = deriveEncoder(renaming.snakeCase)
   }
+
+  case class Update(
+    description: Option[String] = None,
+    name: Option[String] = None,
+    stateful: Option[Boolean] = None
+  )
 
   object Create {
     implicit val decoder: Encoder[Create] = deriveEncoder(renaming.snakeCase)
@@ -25,11 +28,9 @@ object SecurityGroup {
     stateful: Option[Boolean] = None
   )
 
-  case class Update(
-    description: Option[String] = None,
-    name: Option[String] = None,
-    stateful: Option[Boolean] = None
-  )
+  object Read {
+    implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
+  }
 
   case class Read(
     name: String,
@@ -43,7 +44,6 @@ object SecurityGroup {
     securityGroupRoles: List[SecurityGroupRule], // Security Group Roles Object
     stateful: Option[String]
   )
-
 }
 
 sealed trait SecurityGroup extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroupRule.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroupRule.scala
@@ -13,16 +13,16 @@ object SecurityGroupRule {
   }
 
   case class Create(
-    projectId: Option[String],
-    remoteIpPrefix: Option[String],
-    portRangeMin: Option[Integer],
-    remoteGroupId: Option[String],
-    description: Option[String],
+    projectId: Option[String] = None,
+    remoteIpPrefix: Option[String] = None,
+    portRangeMin: Option[Integer] = None,
+    remoteGroupId: Option[String] = None,
+    description: Option[String] = None,
     direction: String,
-    protocol: Option[String],
-    ehtertype: Option[String],
+    protocol: Option[String] = None,
+    ethertype: Option[String] = None,
     securityGroupId: String,
-    portRangeMax: Option[Integer],
+    portRangeMax: Option[Integer] = None,
   )
 }
 
@@ -36,7 +36,7 @@ case class SecurityGroupRule(
   description: String,
   direction: String,
   protocol: String,
-  ehtertype: String,
+  ethertype: String,
   securityGroupId: String,
   portRangeMax: Integer,
   revisionNumber: Integer,

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroupRule.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroupRule.scala
@@ -2,8 +2,8 @@ package pt.tecnico.dsi.neutron.models
 
 import java.time.LocalDateTime
 
+import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
 import io.circe.{Decoder, Encoder}
-import io.circe.derivation.{deriveDecoder, renaming, deriveEncoder}
 
 object SecurityGroupRule {
   implicit val decoder: Decoder[SecurityGroupRule] = deriveDecoder(renaming.snakeCase)
@@ -24,6 +24,7 @@ object SecurityGroupRule {
     securityGroupId: String,
     portRangeMax: Option[Integer] = None,
   )
+
 }
 
 case class SecurityGroupRule(

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroupRule.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/SecurityGroupRule.scala
@@ -1,0 +1,44 @@
+package pt.tecnico.dsi.neutron.models
+
+import java.time.LocalDateTime
+
+import io.circe.{Decoder, Encoder}
+import io.circe.derivation.{deriveDecoder, renaming, deriveEncoder}
+
+object SecurityGroupRule {
+  implicit val decoder: Decoder[SecurityGroupRule] = deriveDecoder(renaming.snakeCase)
+
+  object Create {
+    implicit val decoder: Encoder[Create] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Create(
+    projectId: Option[String],
+    remoteIpPrefix: Option[String],
+    portRangeMin: Option[Integer],
+    remoteGroupId: Option[String],
+    description: Option[String],
+    direction: String,
+    protocol: Option[String],
+    ehtertype: Option[String],
+    securityGroupId: String,
+    portRangeMax: Option[Integer],
+  )
+}
+
+case class SecurityGroupRule(
+  projectId: String,
+  createdAt: LocalDateTime,
+  updatedAt: LocalDateTime,
+  remoteIpPrefix: String,
+  portRangeMin: Integer,
+  remoteGroupId: String,
+  description: String,
+  direction: String,
+  protocol: String,
+  ehtertype: String,
+  securityGroupId: String,
+  portRangeMax: Integer,
+  revisionNumber: Integer,
+)
+

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Subnet.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Subnet.scala
@@ -7,12 +7,10 @@ import io.circe.derivation.{deriveDecoder, deriveEncoder, renaming}
 import io.circe.{Decoder, Encoder}
 
 object Subnet {
-
   // For lack of a better name
   sealed trait Ipv6Mode extends EnumEntry
 
   case object Ipv6Mode extends Enum[Ipv6Mode] {
-
     implicit val circeEncoder: Encoder[Ipv6Mode] = Encoder.encodeString.contramap {
       case Slaac => "slaac"
       case Dhcpv6Stateful => "dhcpv6-stateful"
@@ -34,30 +32,9 @@ object Subnet {
     val values: IndexedSeq[Ipv6Mode] = findValues
   }
 
-  object Read {
-    implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
-  }
-
   object Create {
     implicit val encoder: Encoder[Create] = deriveEncoder(renaming.snakeCase)
   }
-
-  object Update {
-    implicit val encoder: Encoder[Update] = deriveEncoder(renaming.snakeCase)
-  }
-
-  case class Update(
-    name: Option[String] = None,
-    enableDhcp: Option[Boolean] = None,
-    dnsNameservers: Option[List[String]] = None, // ???
-    allocationPools: Option[List[Map[String, String]]] = None, // ???
-    hostRoutes: Option[List[Map[String, String]]] = None, // ???
-    gatewayIp: Option[String] = None,
-    description: Option[String] = None,
-    serviceTypes: Option[List[String]] = None,
-    segmentId: Option[String] = None,
-    dnsPublishFixedIp: Option[Boolean] = None
-  )
 
   case class Create(
     projectId: Option[String] = None,
@@ -80,6 +57,27 @@ object Subnet {
     serviceTypes: List[String] = Nil,
     dnsPublishFixedIp: Option[Boolean] = None
   )
+
+  object Update {
+    implicit val encoder: Encoder[Update] = deriveEncoder(renaming.snakeCase)
+  }
+
+  case class Update(
+    name: Option[String] = None,
+    enableDhcp: Option[Boolean] = None,
+    dnsNameservers: Option[List[String]] = None, // ???
+    allocationPools: Option[List[Map[String, String]]] = None, // ???
+    hostRoutes: Option[List[Map[String, String]]] = None, // ???
+    gatewayIp: Option[String] = None,
+    description: Option[String] = None,
+    serviceTypes: Option[List[String]] = None,
+    segmentId: Option[String] = None,
+    dnsPublishFixedIp: Option[Boolean] = None
+  )
+
+  object Read {
+    implicit val decoder: Decoder[Read] = deriveDecoder(renaming.snakeCase)
+  }
 
   case class Read(
     name: String,

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/Subnet.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/Subnet.scala
@@ -10,6 +10,7 @@ object Subnet {
 
   // For lack of a better name
   sealed trait Ipv6Mode extends EnumEntry
+
   case object Ipv6Mode extends Enum[Ipv6Mode] {
 
     implicit val circeEncoder: Encoder[Ipv6Mode] = Encoder.encodeString.contramap {
@@ -25,7 +26,9 @@ object Subnet {
     }
 
     case object Slaac extends Ipv6Mode
+
     case object Dhcpv6Stateful extends Ipv6Mode
+
     case object Dhcpv6Stateless extends Ipv6Mode
 
     val values: IndexedSeq[Ipv6Mode] = findValues
@@ -107,6 +110,7 @@ object Subnet {
     dnsPublishFixedIp: Boolean,
     //serviceTypes: List[???],
   )
+
 }
 
 sealed trait Subnet extends Model {

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/package.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/package.scala
@@ -1,6 +1,5 @@
 package pt.tecnico.dsi.neutron
 
-import java.net.Inet4Address
 import java.net.InetAddress
 
 import io.circe.{Decoder, Encoder}

--- a/src/main/scala/pt/tecnico/dsi/neutron/models/package.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/models/package.scala
@@ -1,5 +1,8 @@
 package pt.tecnico.dsi.neutron
 
+import java.net.Inet4Address
+import java.net.InetAddress
+
 import io.circe.{Decoder, Encoder}
 import squants.information.Information
 import squants.information.InformationConversions._
@@ -7,4 +10,7 @@ import squants.information.InformationConversions._
 package object models {
   implicit val decoderInformation: Decoder[Information] = Decoder.decodeInt.map(_.gibibytes)
   implicit val encoderInformation: Encoder[Information] = Encoder.encodeInt.contramap(_.toGibibytes.ceil.toInt)
+
+  implicit val ipv4Decoder: Decoder[InetAddress] = Decoder.decodeString.map(InetAddress.getByName)
+  implicit val ipv4Encoder: Encoder[InetAddress] = Encoder.encodeString.contramap(_.getHostAddress)
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/CrudService.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/CrudService.scala
@@ -8,9 +8,9 @@ import pt.tecnico.dsi.neutron.models.Model
 import pt.tecnico.dsi.openstack.common.models.WithId
 import pt.tecnico.dsi.openstack.common.services.{CrudService => CommonCrudService}
 
-abstract class CrudService[F[_]: Sync: Client, T <: Model]
-   (baseUri: Uri, name: String, authToken: Header)
-   (implicit e: Encoder[T#Create], f: Encoder[T#Update], g: Decoder[T#Read])
+abstract class CrudService[F[_] : Sync : Client, T <: Model]
+(baseUri: Uri, name: String, authToken: Header)
+  (implicit e: Encoder[T#Create], f: Encoder[T#Update], g: Decoder[T#Read])
   extends CommonCrudService[F, T#Read, T#Create, T#Update](baseUri, name, authToken) {
 
   type Create = T#Create

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/FloatingIps.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/FloatingIps.scala
@@ -3,9 +3,7 @@ package pt.tecnico.dsi.neutron.services
 import cats.effect.Sync
 import org.http4s.client.Client
 import org.http4s.{Header, Uri}
-import pt.tecnico.dsi.neutron.models.{FloatingIp, Subnet}
+import pt.tecnico.dsi.neutron.models.FloatingIp
 
-final class FloatingIps[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
-  extends CrudService[F, FloatingIp](baseUri, "floatingip", authToken) {
-
-}
+final class FloatingIps[F[_] : Sync : Client](baseUri: Uri, authToken: Header)
+  extends CrudService[F, FloatingIp](baseUri, "floatingip", authToken)

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/FloatingIps.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/FloatingIps.scala
@@ -1,0 +1,11 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import org.http4s.client.Client
+import org.http4s.{Header, Uri}
+import pt.tecnico.dsi.neutron.models.{FloatingIp, Subnet}
+
+final class FloatingIps[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+  extends CrudService[F, FloatingIp](baseUri, "floatingip", authToken) {
+
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Networks.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Networks.scala
@@ -6,6 +6,4 @@ import org.http4s.client.Client
 import pt.tecnico.dsi.neutron.models.Network
 
 final class Networks[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
-  extends CrudService[F, Network](baseUri, "network", authToken) with BulkCreate[F, Network] {
-
-}
+  extends CrudService[F, Network](baseUri, "network", authToken) with BulkCreate[F, Network]

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Networks.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Networks.scala
@@ -1,9 +1,9 @@
 package pt.tecnico.dsi.neutron.services
 
 import cats.effect.Sync
-import org.http4s.{Header, Uri}
 import org.http4s.client.Client
+import org.http4s.{Header, Uri}
 import pt.tecnico.dsi.neutron.models.Network
 
-final class Networks[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+final class Networks[F[_] : Sync : Client](baseUri: Uri, authToken: Header)
   extends CrudService[F, Network](baseUri, "network", authToken) with BulkCreate[F, Network]

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Networks.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Networks.scala
@@ -1,0 +1,11 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import org.http4s.{Header, Uri}
+import org.http4s.client.Client
+import pt.tecnico.dsi.neutron.models.Network
+
+final class Networks[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+  extends CrudService[F, Network](baseUri, "network", authToken) with BulkCreate[F, Network] {
+
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Ports.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Ports.scala
@@ -3,8 +3,8 @@ package pt.tecnico.dsi.neutron.services
 import cats.effect.Sync
 import org.http4s.client.Client
 import org.http4s.{Header, Uri}
-import pt.tecnico.dsi.neutron.models.{Port, Subnet}
+import pt.tecnico.dsi.neutron.models.Port
 
-final class Ports[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+final class Ports[F[_] : Sync : Client](baseUri: Uri, authToken: Header)
   extends CrudService[F, Port](baseUri, "port", authToken) with BulkCreate[F, Port]
 

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Ports.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Ports.scala
@@ -6,6 +6,5 @@ import org.http4s.{Header, Uri}
 import pt.tecnico.dsi.neutron.models.{Port, Subnet}
 
 final class Ports[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
-  extends CrudService[F, Port](baseUri, "port", authToken) with BulkCreate[F, Port] {
+  extends CrudService[F, Port](baseUri, "port", authToken) with BulkCreate[F, Port]
 
-}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Ports.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Ports.scala
@@ -1,0 +1,11 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import org.http4s.client.Client
+import org.http4s.{Header, Uri}
+import pt.tecnico.dsi.neutron.models.{Port, Subnet}
+
+final class Ports[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+  extends CrudService[F, Port](baseUri, "port", authToken) with BulkCreate[F, Port] {
+
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/RouterInterfaces.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/RouterInterfaces.scala
@@ -1,0 +1,20 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import org.http4s.client.Client
+import org.http4s.{Header, Uri}
+import pt.tecnico.dsi.neutron.models.RouterInterface
+import pt.tecnico.dsi.openstack.common.models.WithId
+import pt.tecnico.dsi.openstack.common.services.Service
+
+final class RouterInterfaces[F[_]: Sync: Client](base: Uri, authToken: Header) extends Service[F](authToken) {
+
+  def addBySubnet(subnetId: String): F[WithId[RouterInterface]] =
+    put(Map("subnet_id" -> subnetId), base / "add_router_interface", wrappedAt = None)
+
+  def addByPort(portId: String): F[WithId[RouterInterface]] =
+    put(Map("port_id" -> portId), base / "add_router_interface", wrappedAt = None)
+
+  def remove(value: RouterInterface.Remove): F[WithId[RouterInterface]] =
+    put(value, base / "add_router_interface", wrappedAt = None)
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/RouterInterfaces.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/RouterInterfaces.scala
@@ -7,7 +7,7 @@ import pt.tecnico.dsi.neutron.models.RouterInterface
 import pt.tecnico.dsi.openstack.common.models.WithId
 import pt.tecnico.dsi.openstack.common.services.Service
 
-final class RouterInterfaces[F[_]: Sync: Client](base: Uri, authToken: Header) extends Service[F](authToken) {
+final class RouterInterfaces[F[_] : Sync : Client](base: Uri, authToken: Header) extends Service[F](authToken) {
 
   def addBySubnet(subnetId: String): F[WithId[RouterInterface]] =
     put(Map("subnet_id" -> subnetId), base / "add_router_interface", wrappedAt = None)

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Routers.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Routers.scala
@@ -1,14 +1,14 @@
 package pt.tecnico.dsi.neutron.services
 
 import cats.effect.Sync
-import io.circe.{Decoder, Encoder}
 import org.http4s.client.Client
 import org.http4s.{Header, Uri}
 import pt.tecnico.dsi.neutron.models.Router
 
-class Routers[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+final class Routers[F[_] : Sync : Client](baseUri: Uri, authToken: Header)
   extends CrudService[F, Router](baseUri, "router", authToken) {
 
   def interface(routerId: String): RouterInterfaces[F] = new RouterInterfaces(baseUri / routerId, authToken)
+
   def extraRoutes(routerId: String): Routes[F] = new Routes(baseUri / routerId, authToken)
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Routers.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Routers.scala
@@ -1,0 +1,15 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import io.circe.{Decoder, Encoder}
+import org.http4s.client.Client
+import org.http4s.{Header, Uri}
+import pt.tecnico.dsi.neutron.models.Router
+
+class Routers[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+  (implicit e: Encoder[Router#Create], f: Encoder[Router#Update], g: Decoder[Router#Read])
+  extends CrudService[F, Router](baseUri, "router", authToken) {
+
+  def interface(routerId: String): RouterInterfaces[F] = new RouterInterfaces(baseUri / routerId, authToken)
+  def extraRoutes(routerId: String): Routes[F] = new Routes(baseUri / routerId, authToken)
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Routers.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Routers.scala
@@ -7,7 +7,6 @@ import org.http4s.{Header, Uri}
 import pt.tecnico.dsi.neutron.models.Router
 
 class Routers[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
-  (implicit e: Encoder[Router#Create], f: Encoder[Router#Update], g: Decoder[Router#Read])
   extends CrudService[F, Router](baseUri, "router", authToken) {
 
   def interface(routerId: String): RouterInterfaces[F] = new RouterInterfaces(baseUri / routerId, authToken)

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Routes.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Routes.scala
@@ -8,9 +8,10 @@ import org.http4s.{Header, Uri}
 import pt.tecnico.dsi.neutron.models.Route
 import pt.tecnico.dsi.openstack.common.services.Service
 
-final class Routes[F[_]: Sync: Client](base: Uri, authToken: Header) extends Service[F](authToken) {
+final class Routes[F[_] : Sync : Client](base: Uri, authToken: Header) extends Service[F](authToken) {
 
   import dsl._
+
   implicit val d: Decoder[List[Route]] = _.downField("router").get("routes")
   implicit val e: Encoder[List[Route]] = e.mapJson(e => Json.obj("router" -> Json.obj("routes" -> e)))
 

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Routes.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Routes.scala
@@ -1,0 +1,23 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import io.circe.{Decoder, Encoder, Json}
+import org.http4s.Method.PUT
+import org.http4s.client.Client
+import org.http4s.{Header, Uri}
+import pt.tecnico.dsi.neutron.models.Route
+import pt.tecnico.dsi.openstack.common.services.Service
+
+final class Routes[F[_]: Sync: Client](base: Uri, authToken: Header) extends Service[F](authToken) {
+
+  import dsl._
+  implicit val d: Decoder[List[Route]] = _.downField("router").get("routes")
+  implicit val e: Encoder[List[Route]] = e.mapJson(e => Json.obj("router" -> Json.obj("routes" -> e)))
+
+  def add(routes: List[Route]): F[List[Route]] =
+    client.expect(PUT(routes, base / "add_extraroutes"))
+
+  def remove(routes: List[Route]): F[List[Route]] =
+    client.expect(PUT(routes, base / "remove_extraroutes"))
+
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroupRules.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroupRules.scala
@@ -1,0 +1,28 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import fs2.Stream
+import org.http4s.client.Client
+import org.http4s.{Header, Query, Uri}
+import pt.tecnico.dsi.neutron.models.SecurityGroupRule
+import pt.tecnico.dsi.openstack.common.models.WithId
+import pt.tecnico.dsi.openstack.common.services.Service
+
+class SecurityGroupRules[F[_]: Sync: Client](baseUri: Uri, authToken: Header) extends Service[F](authToken) {
+
+  val name = "security-group-rule"
+  val pluralName = s"${name}s"
+  val uri: Uri = baseUri / pluralName
+
+  def list(): Stream[F, WithId[SecurityGroupRule]] = list(Query.empty)
+  def list(query: Query): Stream[F, WithId[SecurityGroupRule]] =
+    super.list[WithId[SecurityGroupRule]](pluralName, uri, query)
+
+  def create(value: SecurityGroupRule.Create): F[WithId[SecurityGroupRule]] =
+    super.post(value, uri, wrappedAt = Some(name))
+
+  def get(id: String): F[WithId[SecurityGroupRule]] = super.get(uri / id, wrappedAt = Some(name))
+
+  def delete(value: WithId[SecurityGroupRule]): F[Unit] = delete(value.id)
+  def delete(id: String): F[Unit] = super.delete(uri / id)
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroupRules.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroupRules.scala
@@ -8,13 +8,14 @@ import pt.tecnico.dsi.neutron.models.SecurityGroupRule
 import pt.tecnico.dsi.openstack.common.models.WithId
 import pt.tecnico.dsi.openstack.common.services.Service
 
-class SecurityGroupRules[F[_]: Sync: Client](baseUri: Uri, authToken: Header) extends Service[F](authToken) {
+final class SecurityGroupRules[F[_] : Sync : Client](baseUri: Uri, authToken: Header) extends Service[F](authToken) {
 
   val name = "security-group-rule"
   val pluralName = s"${name}s"
   val uri: Uri = baseUri / pluralName
 
   def list(): Stream[F, WithId[SecurityGroupRule]] = list(Query.empty)
+
   def list(query: Query): Stream[F, WithId[SecurityGroupRule]] =
     super.list[WithId[SecurityGroupRule]](pluralName, uri, query)
 
@@ -24,5 +25,6 @@ class SecurityGroupRules[F[_]: Sync: Client](baseUri: Uri, authToken: Header) ex
   def get(id: String): F[WithId[SecurityGroupRule]] = super.get(uri / id, wrappedAt = Some(name))
 
   def delete(value: WithId[SecurityGroupRule]): F[Unit] = delete(value.id)
+
   def delete(id: String): F[Unit] = super.delete(uri / id)
 }

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroups.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroups.scala
@@ -6,6 +6,4 @@ import org.http4s.{Header, Uri}
 import pt.tecnico.dsi.neutron.models.{FloatingIp, SecurityGroup}
 
 final class SecurityGroups[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
-  extends CrudService[F, SecurityGroup](baseUri, "security-group", authToken) {
-
-}
+  extends CrudService[F, SecurityGroup](baseUri, "security-group", authToken)

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroups.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroups.scala
@@ -1,0 +1,11 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import org.http4s.client.Client
+import org.http4s.{Header, Uri}
+import pt.tecnico.dsi.neutron.models.{FloatingIp, SecurityGroup}
+
+final class SecurityGroups[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+  extends CrudService[F, SecurityGroup](baseUri, "security-group", authToken) {
+
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroups.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/SecurityGroups.scala
@@ -3,7 +3,7 @@ package pt.tecnico.dsi.neutron.services
 import cats.effect.Sync
 import org.http4s.client.Client
 import org.http4s.{Header, Uri}
-import pt.tecnico.dsi.neutron.models.{FloatingIp, SecurityGroup}
+import pt.tecnico.dsi.neutron.models.SecurityGroup
 
-final class SecurityGroups[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+final class SecurityGroups[F[_] : Sync : Client](baseUri: Uri, authToken: Header)
   extends CrudService[F, SecurityGroup](baseUri, "security-group", authToken)

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Subnets.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Subnets.scala
@@ -6,6 +6,4 @@ import org.http4s.{Header, Uri}
 import pt.tecnico.dsi.neutron.models.{Network, Subnet}
 
 final class Subnets[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
-  extends CrudService[F, Subnet](baseUri, "subnet", authToken) with BulkCreate[F, Subnet] {
-
-}
+  extends CrudService[F, Subnet](baseUri, "subnet", authToken) with BulkCreate[F, Subnet]

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Subnets.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Subnets.scala
@@ -1,0 +1,11 @@
+package pt.tecnico.dsi.neutron.services
+
+import cats.effect.Sync
+import org.http4s.client.Client
+import org.http4s.{Header, Uri}
+import pt.tecnico.dsi.neutron.models.{Network, Subnet}
+
+final class Subnets[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+  extends CrudService[F, Subnet](baseUri, "subnet", authToken) with BulkCreate[F, Subnet] {
+
+}

--- a/src/main/scala/pt/tecnico/dsi/neutron/services/Subnets.scala
+++ b/src/main/scala/pt/tecnico/dsi/neutron/services/Subnets.scala
@@ -3,7 +3,7 @@ package pt.tecnico.dsi.neutron.services
 import cats.effect.Sync
 import org.http4s.client.Client
 import org.http4s.{Header, Uri}
-import pt.tecnico.dsi.neutron.models.{Network, Subnet}
+import pt.tecnico.dsi.neutron.models.Subnet
 
-final class Subnets[F[_]: Sync: Client](baseUri: Uri, authToken: Header)
+final class Subnets[F[_] : Sync : Client](baseUri: Uri, authToken: Header)
   extends CrudService[F, Subnet](baseUri, "subnet", authToken) with BulkCreate[F, Subnet]


### PR DESCRIPTION
Added Routers, Security-Groups and Security-Group-Roles services and models.
I left integration tests to the end because that's what made sense, since we first want to agree on a pleasant programming interface  to use.

Here are the implemented and missing services:
```
Neutron (Network):

[Simão]

     GET   /v2.0/quotas                        List quotas for projects with non-default quota values
     GET   /v2.0/quotas/{project_id}           List quotas for a project
     PUT   /v2.0/quotas/{project_id}           Update quota for a project
  DELETE   /v2.0/quotas/{project_id}           Reset quota for a project
     GET   /v2.0/quotas/{project_id}/default   List default quotas for a project

[Me]

X    GET   /v2.0/security-groups                       List security groups
X   POST   /v2.0/security-groups                       Create security group
X    GET   /v2.0/security-groups/{security_group_id}   Show security group
X    PUT   /v2.0/security-groups/{security_group_id}   Update security group
X DELETE   /v2.0/security-groups/{security_group_id}   Delete security group

X    GET   /v2.0/security-group-rules                            List security group rules
X   POST   /v2.0/security-group-rules                            Create security group rule
X    GET   /v2.0/security-group-rules/{security_group_rule_id}   Show security group rule
X DELETE   /v2.0/security-group-rules/{security_group_rule_id}   Delete security group rule

X    GET   /v2.0/networks/{network_id}    Show network details
X    PUT   /v2.0/networks/{network_id}    Update network
X DELETE   /v2.0/networks/{network_id}    Delete network
X    GET   /v2.0/networks                 List networks
X       - Lots of query parameters can be made into methods
X   POST   /v2.0/networks                 Create network
X   POST   /v2.0/networks                 Bulk Create network

X    GET   /v2.0/ports/{port_id}  Show port details
X    PUT   /v2.0/ports/{port_id}  Update port
X DELETE   /v2.0/ports/{port_id}  Delete port
X    GET   /v2.0/ports            List ports
X   POST   /v2.0/ports            Create port

X    GET   /v2.0/floatingips                   List floating IPs
X   POST   /v2.0/floatingips                   Create floating IP
X    GET   /v2.0/floatingips/{floatingip_id}   Show floating IP details
X    PUT   /v2.0/floatingips/{floatingip_id}   Update floating IP
X DELETE   /v2.0/floatingips/{floatingip_id}   Delete floating IP

X    GET   /v2.0/routers                List routers
X   POST   /v2.0/routers                Create router
X    GET   /v2.0/routers/{router_id}    Show router details
X    PUT   /v2.0/routers/{router_id}    Update router
X DELETE   /v2.0/routers/{router_id}    Delete router

X    PUT   /v2.0/routers/{router_id}/add_router_interface       Add interface to router
X    PUT   /v2.0/routers/{router_id}/remove_router_interface    Remove interface from router
X    PUT   /v2.0/routers/{router_id}/add_extraroutes            Add extra routes to router
X    PUT   /v2.0/routers/{router_id}/remove_extraroutes         Remove extra routes from router

X     GET   /v2.0/subnets               List subnets
X    POST   /v2.0/subnets               Create subnet
X    POST   /v2.0/subnets               Bulk create subnet
X     GET   /v2.0/subnets/{subnet_id}   Show subnet details
X     PUT   /v2.0/subnets/{subnet_id}   Update subnet
X  DELETE   /v2.0/subnets/{subnet_id}   Delete subnet
```